### PR TITLE
fix: improve sun and moon icon contrast in ThemeToggle

### DIFF
--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -41,7 +41,7 @@ const isToggleEnabled = computed({
       aria-hidden="true"
       focusable="false"
       viewBox="0 0 24 24"
-      class="absolute right-6 h-3 w-3 fill-gray-500"
+      class="absolute right-6 h-3 w-3 fill-white"
     >
       <path
         d="M12,18c-3.3,0-6-2.7-6-6s2.7-6,6-6s6,2.7,6,6S15.3,18,12,18zM12,8c-2.2,0-4,1.8-4,4c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4C16,9.8,14.2,8,12,8z"
@@ -70,7 +70,7 @@ const isToggleEnabled = computed({
       aria-hidden="true"
       focusable="false"
       viewBox="0 0 24 24"
-      class="absolute right-1 h-3 w-3 fill-gray-400"
+      class="absolute right-1 h-3 w-3 fill-base-100"
     >
       <path
         d="M12.1,22c-0.3,0-0.6,0-0.9,0c-5.5-0.5-9.5-5.4-9-10.9c0.4-4.8,4.2-8.6,9-9c0.4,0,0.8,0.2,1,0.5c0.2,0.3,0.2,0.8-0.1,1.1c-2,2.7-1.4,6.4,1.3,8.4c2.1,1.6,5,1.6,7.1,0c0.3-0.2,0.7-0.3,1.1-0.1c0.3,0.2,0.5,0.6,0.5,1c-0.2,2.7-1.5,5.1-3.6,6.8C16.6,21.2,14.4,22,12.1,22zM9.3,4.4c-2.9,1-5,3.6-5.2,6.8c-0.4,4.4,2.8,8.3,7.2,8.7c2.1,0.2,4.2-0.4,5.8-1.8c1.1-0.9,1.9-2.1,2.4-3.4c-2.5,0.9-5.3,0.5-7.5-1.1C9.2,11.4,8.1,7.7,9.3,4.4z"


### PR DESCRIPTION
## Summary
- Sun icon: `fill-gray-500` → `fill-white` — alto contraste contra los thumbs oscuros (`primary/40`) en modo claro
- Moon icon: `fill-gray-400` → `fill-base-100` — usa el color de fondo del tema (muy oscuro en dark modes), alto contraste contra thumbs brillantes (`primary`) en modo oscuro

## Test plan
- [ ] Default light: sol visible (blanco sobre thumb azul-navy muted)
- [ ] Default dark: luna visible (dark sobre thumb azul claro `#80B2ED`)
- [ ] Neon light: sol visible (blanco sobre thumb verde muted)
- [ ] Neon dark: luna visible (dark sobre thumb verde brillante `#00E054`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)